### PR TITLE
Update hashibox.pkr.hcl

### DIFF
--- a/packer/hashibox.pkr.hcl
+++ b/packer/hashibox.pkr.hcl
@@ -27,7 +27,7 @@ variable "fedora_iso_url" {
 
 variable "fedora_iso_checksum" {
   type        = string
-  default     = "file:https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/aarch64/images/Fedora-Cloud-40-1.14-aarch64-CHECKSUM"
+  default     = "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/aarch64/images/Fedora-Cloud-40-1.14-aarch64-CHECKSUM"
   description = "Checksum in the packer format of the cloud image"
 }
 


### PR DESCRIPTION
I think there's a typo in fedora checksum block, where `file:https://` are together in URL. Please feel free to merge, its a small clerical pick.