### PR TITLE
Update hashibox.yaml

### DIFF
--- a/scenarios/lima/aio/hashibox.yaml
+++ b/scenarios/lima/aio/hashibox.yaml
@@ -22,6 +22,9 @@ provision:
       connect {
         enabled = true
       }
+      ports {
+        grpc = 8502
+      }
       EOF
 
   - mode: system # configure Nomad


### PR DESCRIPTION
Enabled `grpc.port = 8502` in hashibox.yaml's consul server config block.